### PR TITLE
Fix links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ See [GitHub's official documentation](https://help.github.com/articles/using-pul
        maintained indefinitely and may be redistributed consistent with
        this project or the open source license(s) involved.
 
-(taken from [developercertificate.org](http://developercertificate.org/))
+(taken from [developercertificate.org](https://developercertificate.org/))
 
 See [LICENSE](https://github.com/ni/<reponame>/blob/master/LICENSE)
 for details about how \<reponame\> is licensed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Contributions to \<reponame\> are welcome from all!
 
 \<reponame\> is managed via [git](https://git-scm.com), with the canonical upstream
-repository hosted on [GitHub](http://developercertificate.org/).
+repository hosted on [GitHub](https://github.com/ni/<reponame>/).
 
 \<reponame\> follows a pull-request model for development.  If you wish to
 contribute, you will need to create a GitHub account, fork this project, push a


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
CONTRIBUTED.MD had a link to developercertificate.org which seemed like it should have been a link to the GitHub repo in question. We should also prefer https links when available, for consistency.

### Why should this Pull Request be merged?
These changes were suggested when I added this template to one of my repos in the pull request at https://github.com/ni/systemlink-OpenAPI-documents/pull/1

### What testing has been done?
N/A
