### PR TITLE
Change default branch name to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,5 +57,5 @@ See [GitHub's official documentation](https://help.github.com/articles/using-pul
 
 (taken from [developercertificate.org](https://developercertificate.org/))
 
-See [LICENSE](https://github.com/ni/<reponame>/blob/master/LICENSE)
+See [LICENSE](https://github.com/ni/<reponame>/blob/main/LICENSE)
 for details about how \<reponame\> is licensed.


### PR DESCRIPTION
### What does this Pull Request accomplish?

New repos are, by default, created with the default branch named "main".  This change updates the CONTRIBUTING.md template to use the new default.

### Why should this Pull Request be merged?

It's a better starting point for new repos.

### What testing has been done?

Recently created a new repo, and it used "main" for the default branch.  https://github.com/ni/idl_ifw_capi/blob/main/CONTRIBUTING.md
